### PR TITLE
fix ruby compat :wrong number of arguments (given 3, expected 2)

### DIFF
--- a/lib/big_query/client/jobs.rb
+++ b/lib/big_query/client/jobs.rb
@@ -40,7 +40,7 @@ module BigQuery
 
         api(
           @client.get_job_query_results(
-            @project_id, id, deep_symbolize_keys(opts)
+            @project_id, id, **deep_symbolize_keys(opts)
           )
         )
       end


### PR DESCRIPTION
lazy.rb
```
def deep_symbolize_keys(opts)
    convert_key_proc = Proc.new { |k| underscore(k.to_s).to_sym }
    Hash[opts.map { |k, v| [convert_key_proc.call(k), process_value(v, convert_key_proc)] }]
  end
  def underscore(str)
    str.gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
    gsub(/([a-z\d])([A-Z])/,'\1_\2').
    tr("-", "_").
    downcase
  end
  def process_value(val, convert_key_proc)
    case val
    when Hash
      Hash[val.map {|k, v| [convert_key_proc.call(k), process_value(v, convert_key_proc)] }]
    when Array
      val.map{ |v| process_value(v, convert_key_proc) }
    else
      val
    end
  end

def get_job_query_results_dummy(project_id, job_id, location: nil, max_results: nil, page_token: nil, start_index: nil, timeout_ms: nil, fields: nil, quota_user: nil, user_ip: nil, options: nil, &block)
    print " HERE - OK"
  end


   def get_query_results(id, opts = {})
       get_job_query_results_dummy(
          'prj_ud', id, **deep_symbolize_keys(opts)
       )
   end
print "START "
  get_query_results('sdfdsfsd', :startIndex => 5) 
```

TEST BEFORE FIX: 
```
# bundle exec rails runner lazy.rb
START lazy.rb:22:in `get_job_query_results_dummy': wrong number of arguments (given 3, expected 2) (ArgumentError)
        from lazy.rb:28:in `get_query_results'
        from lazy.rb:33:in `<main>'
```

TEST AFTER FIX: 
```
# bundle exec rails runner lazy.rb
START  HERE - OK% 
```